### PR TITLE
feat: add redirect_to param google-auth

### DIFF
--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -12,7 +12,6 @@ function getTokenFromLocalStorage() {
 
 export function getOauthTokenOrRedirect(): string {
   const tokenFromUrl = getTokenFromUrl();
-
   if (tokenFromUrl) {
     window.localStorage.setItem(OAUTH_KEY_STORAGE_KEY, tokenFromUrl);
     return tokenFromUrl;
@@ -35,7 +34,7 @@ export const LOGIN_PAGE_URL =
   "https://octo-moss-back.herokuapp.com/auth/google_oauth2";
 
 export function redirectToLoginPage() {
-  window.location.href = LOGIN_PAGE_URL;
+  window.location.href = `${LOGIN_PAGE_URL}?redirect_to=${window.location.href}`;
 }
 
 export function clearOauthToken() {


### PR DESCRIPTION
Fix #4 [moss-front](https://github.com/octo-wam/moss-front/issues/4)

This new param is used by our back-end to redirect the user where he
first started his experience.
If not provided it fallsback to the homepage.

Related PR : https://github.com/octo-wam/moss-back/pull/11 

Made with ♥️ by ALME && YCWA skool'16


Je n'arrive pas à lancer les tests cypress en local, "accounts.google" n'autorise pas la connexion. Je regarderais ça demain matin.